### PR TITLE
Rework `acts_as_hypertable` default scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ options = {
 create_continuous_aggregates('ohlc_1m', query, **options)
 ```
 
-### Hypertable Helpers
+### Enable ActsAsHypertable
 
-You can say `acts_as_hypertable` to get access to some basic scopes for your
+You can declare a Rails model as a Hypertable by invoking the `acts_as_hypertable` macro. This macro extends your existing model with timescaledb-related functionality.
 model:
 
 ```ruby
@@ -178,88 +178,65 @@ class Event < ActiveRecord::Base
 end
 ```
 
-After including the helpers, several methods from timescaledb will be available in the
-model.
+By default, ActsAsHypertable assumes a record's _time_column_ is called `created_at`.
+
+### Options
+
+If you are using a different time_column name, you can specify it as follows when invoking the `acts_as_hypertable` macro:
+
+```ruby
+class Event < ActiveRecord::Base
+  self.primary_key = "identifier"
+
+  acts_as_hypertable time_column: :timestamp
+end
+```
 
 ### Chunks
 
-To get chunks from a single hypertable, you can use the `.chunks` directly from
-the model name.
+To get all the chunks from a model's hypertable, you can use `.chunks`.
 
 ```ruby
-Event.chunks
-# DEBUG: Timescale::Chunk Load (9.0ms)  SELECT "timescaledb_information"."chunks".* FROM "timescaledb_information"."chunks" WHERE "timescaledb_information"."chunks"."hypertable_name" = $1  [["hypertable_name", "events"]]
-# => [#<Timescale::Chunk:0x00007f94b0c86008
-#   hypertable_schema: "public",
-#   hypertable_name: "events",
-#   chunk_schema: "_timescaledb_internal",
-#   chunk_name: "_hyper_180_74_chunk",
-#   primary_dimension: "created_at",
-#   primary_dimension_type: "timestamp without time zone",
-#   range_start: 2021-09-22 21:28:00 +0000,
-#   range_end: 2021-09-22 21:29:00 +0000,
-#   range_start_integer: nil,
-#   range_end_integer: nil,
-#   is_compressed: false,
-#   chunk_tablespace: nil,
-#   data_nodes: nil>
+Event.chunks # => [#<Timescale::Chunk>, ...]
 ```
 
-To get all hypertables you can use `Timescale.hypertables` method.
+### Hypertable metadata
 
-### Hypertable metadata from model
-
-To get all details from hypertable, you can access the `.hypertable` from the
-model.
+To get the models' hypertable metadata, you can use `.hypertable`.
 
 ```ruby
-Event.hypertable
-# Timescale::Hypertable Load (4.8ms)  SELECT "timescaledb_information"."hypertables".* FROM "timescaledb_information"."hypertables" WHERE "timescaledb_information"."hypertables"."hypertable_name" = $1 LIMIT $2  [["hypertable_name", "events"], ["LIMIT", 1]]
-# => #<Timescale::Hypertable:0x00007f94c3151cd8
-#  hypertable_schema: "public",
-#  hypertable_name: "events",
-#  owner: "jonatasdp",
-#  num_dimensions: 1,
-#  num_chunks: 1,
-#  compression_enabled: true,
-#  is_distributed: false,
-#  replication_factor: nil,
-#  data_nodes: nil,
-#  tablespaces: nil>
+Event.hypertable # => #<Timescale::Hypertable>
 ```
 
-You can also use `Timescale.hypertables` to have access of all hypertables
-metadata.
+To get all hypertable metadata for all hypertables: `Timescale.hypertables`
 
 ### Compression Settings
 
 Compression settings are accessible through the hypertable.
 
 ```ruby
-Event.hypertable.compression_settings
-#  Timescale::Hypertable Load (1.2ms)  SELECT "timescaledb_information"."hypertables".* FROM "timescaledb_information"."hypertables" WHERE "timescaledb_information"."hypertables"."hypertable_name" = $1 LIMIT $2  [["hypertable_name", "events"], ["LIMIT", 1]]
-#  Timescale::CompressionSettings Load (1.2ms)  SELECT "timescaledb_information"."compression_settings".* FROM "timescaledb_information"."compression_settings" WHERE "timescaledb_information"."compression_settings"."hypertable_name" = $1  [["hypertable_name", "events"]]
-# => [#<Timescale::CompressionSettings:0x00007f94b0bf7010
-#   hypertable_schema: "public",
-#   hypertable_name: "events",
-#   attname: "identifier",
-#   segmentby_column_index: 1,
-#   orderby_column_index: nil,
-#   orderby_asc: nil,
-#   orderby_nullsfirst: nil>,
-#  #<Timescale::CompressionSettings:0x00007f94b0c3e460
-#   hypertable_schema: "public",
-#   hypertable_name: "events",
-#   attname: "created_at",
-#   segmentby_column_index: nil,
-#   orderby_column_index: 1,
-#   orderby_asc: true,
-#   orderby_nullsfirst: false>]
+Event.hypertable.compression_settings # => [#<Timescale::CompressionSettings>, ...]
 ```
 
-It's also possible to access all data calling `Timescale.compression_settings`.
+To get all compression settings for all hypertables: `Timescale.compression_settings`.
 
-### RSpec Hooks
+### Scopes
+
+When you enable ActsAsHypertable on your model, we include a couple default scopes. They are:
+
+| Scope name             | Description                                           |
+|------------------------|-------------------------------------------------------|
+| `Model.previous_month` | Returns all the records created in the previous month |
+| `Model.previous_week`  | Returns all the records created in the previous week  |
+| `Model.this_month`     | Returns all the records created this month            |
+| `Model.this_week`      | Returns all the records created this week             |
+| `Model.yesterday`      | Returns all the records created yesterday             |
+| `Model.today`          | Returns all the records created today                 |
+| `Model.last_hour`      | Returns all the records created in the last hour      |
+
+All time-related scopes respect your application's timezone.
+
+## RSpec Hooks
 
 In case you want to use TimescaleDB on a Rails environment, you may have some
 issues as the schema dump used for tests is not considering hypertables

--- a/lib/timescale/acts_as_hypertable.rb
+++ b/lib/timescale/acts_as_hypertable.rb
@@ -83,11 +83,41 @@ module Timescale
       end
 
       def define_default_scopes
-        scope :last_month, -> { where("#{time_column} > ?", 1.month.ago) }
-        scope :last_week, -> { where("#{time_column} > ?", 1.week.ago) }
-        scope :last_hour, -> { where("#{time_column} > ?", 1.hour.ago) }
-        scope :yesterday, -> { where("#{time_column} = ?", 1.day.ago.to_date) }
-        scope :today, -> { where("#{time_column} = ?", Date.today) }
+        scope :previous_month, -> do
+          where(
+            "DATE(#{time_column}) >= :start_time AND DATE(#{time_column}) <= :end_time",
+            start_time: Date.today.last_month.in_time_zone.beginning_of_month.to_date,
+            end_time: Date.today.last_month.in_time_zone.end_of_month.to_date
+          )
+        end
+
+        scope :previous_week, -> do
+          where(
+            "DATE(#{time_column}) >= :start_time AND DATE(#{time_column}) <= :end_time",
+            start_time: Date.today.last_week.in_time_zone.beginning_of_week.to_date,
+            end_time: Date.today.last_week.in_time_zone.end_of_week.to_date
+          )
+        end
+
+        scope :this_month, -> do
+          where(
+            "DATE(#{time_column}) >= :start_time AND DATE(#{time_column}) <= :end_time",
+            start_time: Date.today.in_time_zone.beginning_of_month.to_date,
+            end_time: Date.today.in_time_zone.end_of_month.to_date
+          )
+        end
+
+        scope :this_week, -> do
+          where(
+            "DATE(#{time_column}) >= :start_time AND DATE(#{time_column}) <= :end_time",
+            start_time: Date.today.in_time_zone.beginning_of_week.to_date,
+            end_time: Date.today.in_time_zone.end_of_week.to_date
+          )
+        end
+
+        scope :yesterday, -> { where("DATE(#{time_column}) = ?", Date.yesterday.in_time_zone.to_date) }
+        scope :today, -> { where("DATE(#{time_column}) = ?", Date.today.in_time_zone.to_date) }
+        scope :last_hour, -> { where("#{time_column} > ?", 1.hour.ago.in_time_zone) }
       end
 
       private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 require "bundler/setup"
 require "pry"
-require 'rspec/its'
+require "rspec/its"
 require "timescale"
-require 'dotenv'
+require "dotenv"
 
 Dotenv.load!
 
@@ -100,7 +100,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.before :suite do
+  config.before :each do
     teardown_tables
     setup_tables
   end

--- a/spec/timescale/acts_as_hypertable_spec.rb
+++ b/spec/timescale/acts_as_hypertable_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Timescale::ActsAsHypertable do
   describe ".hypertable" do
     subject { Event.hypertable }
 
-    it 'has compression enabled by default' do
+    it "has compression enabled by default" do
       is_expected.to be_compression_enabled
     end
 
@@ -32,5 +32,332 @@ RSpec.describe Timescale::ActsAsHypertable do
     its(:num_dimensions) { is_expected.to eq(1) }
     its(:tablespaces) { is_expected.to be_nil }
     its(:hypertable_name) { is_expected.to eq(Event.table_name) }
+  end
+
+  describe ".previous_month" do
+    context "when there are database records that were created in the previous month" do
+      let(:event_last_month) {
+        Event.create!(
+          identifier: "last_month",
+          payload: {name: "bar", value: 2},
+          created_at: Date.today.last_month
+        )
+      }
+      let(:event_one_day_outside_window) {
+        Event.create!(
+          identifier: "one_day_outside_window",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.last_month.beginning_of_month - 1.day
+        )
+      }
+      let(:event_at_edge_of_window) {
+        Event.create!(
+          identifier: "at_edge_of_window",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.last_month.end_of_month
+        )
+      }
+      let(:event_this_month) {
+        Event.create!(
+          identifier: "this_month",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today
+        )
+      }
+
+      it "returns all the records that were created in the previous month" do
+        aggregate_failures do
+          expect(Event.previous_month).to match_array([event_last_month, event_at_edge_of_window])
+          expect(Event.previous_month)
+            .not_to include(event_one_day_outside_window, event_this_month)
+        end
+      end
+    end
+
+    context "when there are no records created in the previous month" do
+      it "returns an empty array" do
+        expect(Event.previous_month).to eq([])
+      end
+    end
+  end
+
+  describe ".previous_week" do
+    context "when there are database records that were created in the previous week" do
+      let(:event_last_week) {
+        Event.create!(
+          identifier: "last_week",
+          payload: {name: "bar", value: 2},
+          created_at: Date.today.last_week
+        )
+      }
+      let(:event_one_day_outside_window) {
+        Event.create!(
+          identifier: "one_day_outside_window",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.last_week.beginning_of_week - 1.day
+        )
+      }
+      let(:event_at_edge_of_window) {
+        Event.create!(
+          identifier: "at_edge_of_window",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.last_week.end_of_week
+        )
+      }
+      let(:event_this_week) {
+        Event.create!(
+          identifier: "this_week",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today
+        )
+      }
+
+      it "returns all the records that were created in the previous week" do
+        aggregate_failures do
+          expect(Event.previous_week).to match_array([event_last_week, event_at_edge_of_window])
+          expect(Event.previous_week)
+            .not_to include(event_one_day_outside_window, event_this_week)
+        end
+      end
+    end
+
+    context "when there are no records created in the previous week" do
+      it "returns an empty array" do
+        expect(Event.previous_week).to eq([])
+      end
+    end
+  end
+
+  describe ".this_month" do
+    context "when there are database records that were created this month" do
+      let(:event_this_month) {
+        Event.create!(
+          identifier: "this_month",
+          payload: {name: "bar", value: 2},
+          created_at: Date.today.beginning_of_month
+        )
+      }
+      let(:event_one_day_outside_window) {
+        Event.create!(
+          identifier: "one_day_outside_window",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.beginning_of_month - 1.day
+        )
+      }
+      let(:event_at_edge_of_window) {
+        Event.create!(
+          identifier: "at_edge_of_window",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.end_of_month
+        )
+      }
+      let(:event_last_month) {
+        Event.create!(
+          identifier: "last_month",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.last_month
+        )
+      }
+      let(:event_next_month) {
+        Event.create!(
+          identifier: "next_week",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.next_month
+        )
+      }
+
+      it "returns all the records that were created this month" do
+        aggregate_failures do
+          expect(Event.this_month).to match_array([event_this_month, event_at_edge_of_window])
+          expect(Event.this_month)
+            .not_to include(event_one_day_outside_window, event_last_month, event_next_month)
+        end
+      end
+    end
+
+    context "when there are no records created this month" do
+      it "returns an empty array" do
+        expect(Event.this_month).to eq([])
+      end
+    end
+  end
+
+  describe ".this_week" do
+    context "when there are database records that were created this week" do
+      let(:event_this_week) {
+        Event.create!(
+          identifier: "this_week",
+          payload: {name: "bar", value: 2},
+          created_at: Date.today
+        )
+      }
+      let(:event_one_day_outside_window) {
+        Event.create!(
+          identifier: "one_day_outside_window",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.beginning_of_week - 1.day
+        )
+      }
+      let(:event_at_edge_of_window) {
+        Event.create!(
+          identifier: "at_edge_of_window",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.end_of_week
+        )
+      }
+      let(:event_last_week) {
+        Event.create!(
+          identifier: "last_week",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.last_week
+        )
+      }
+      let(:event_next_week) {
+        Event.create!(
+          identifier: "next_week",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.next_week
+        )
+      }
+
+      it "returns all the records that were created this week" do
+        aggregate_failures do
+          expect(Event.this_week).to match_array([event_this_week, event_at_edge_of_window])
+          expect(Event.this_week)
+            .not_to include(event_one_day_outside_window, event_last_week, event_next_week)
+        end
+      end
+    end
+
+    context "when there are no records created this week" do
+      it "returns an empty array" do
+        expect(Event.this_week).to eq([])
+      end
+    end
+  end
+
+  describe ".yesterday" do
+    context "when there are database records that were created yesterday" do
+      let(:event_yesterday) {
+        Event.create!(
+          identifier: "yesterday",
+          payload: {name: "bar", value: 2},
+          created_at: Date.yesterday
+        )
+      }
+      let(:event_one_day_outside_window) {
+        Event.create!(
+          identifier: "one_day_outside_window",
+          payload: {name: "bax", value: 2},
+          created_at: Date.yesterday - 1.day
+        )
+      }
+      let(:event_at_edge_of_window) {
+        Event.create!(
+          identifier: "at_edge_of_window",
+          payload: {name: "bax", value: 2},
+          created_at: Date.yesterday.midnight
+        )
+      }
+      let(:event_today) {
+        Event.create!(
+          identifier: "today",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today
+        )
+      }
+
+      it "returns all the records that were created yesterday" do
+        aggregate_failures do
+          expect(Event.yesterday).to match_array([event_yesterday, event_at_edge_of_window])
+          expect(Event.yesterday)
+            .not_to include(event_one_day_outside_window, event_today)
+        end
+      end
+    end
+
+    context "when there are no records created yesterday" do
+      it "returns an empty array" do
+        expect(Event.yesterday).to eq([])
+      end
+    end
+  end
+
+  describe ".today" do
+    context "when there are database records that were created today" do
+      let(:event_today) {
+        Event.create!(
+          identifier: "today",
+          payload: {name: "bar", value: 2},
+          created_at: Date.today
+        )
+      }
+      let(:event_one_day_outside_window) {
+        Event.create!(
+          identifier: "one_day_outside_window",
+          payload: {name: "bax", value: 2},
+          created_at: Date.yesterday
+        )
+      }
+      let(:event_at_edge_of_window) {
+        Event.create!(
+          identifier: "at_edge_of_window",
+          payload: {name: "bax", value: 2},
+          created_at: Date.today.midnight
+        )
+      }
+
+      it "returns all the records that were created today" do
+        aggregate_failures do
+          expect(Event.today).to match_array([event_today, event_at_edge_of_window])
+          expect(Event.today).not_to include(event_one_day_outside_window)
+        end
+      end
+    end
+
+    context "when there are no records created today" do
+      it "returns an empty array" do
+        expect(Event.today).to eq([])
+      end
+    end
+  end
+
+  describe ".last_hour" do
+    context "when there are database records that were created in the last hour" do
+      let(:event_last_hour) {
+        Event.create!(
+          identifier: "last_hour",
+          payload: {name: "bar", value: 2},
+          created_at: Time.now
+        )
+      }
+      let(:event_one_minute_outside_window) {
+        Event.create!(
+          identifier: "one_minute_outside_window",
+          payload: {name: "bax", value: 2},
+          created_at: 1.hour.ago - 1.minute
+        )
+      }
+      let(:event_at_edge_of_window) {
+        Event.create!(
+          identifier: "at_edge_of_window",
+          payload: {name: "bax", value: 2},
+          created_at: Time.now.end_of_hour
+        )
+      }
+
+      it "returns all the records that were created today" do
+        aggregate_failures do
+          expect(Event.last_hour).to match_array([event_last_hour, event_at_edge_of_window])
+          expect(Event.last_hour).not_to include(event_one_minute_outside_window)
+        end
+      end
+    end
+
+    context "when there are no records created in the last hour" do
+      it "returns an empty array" do
+        expect(Event.last_hour).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
Hey @jonatas, thanks for accepting my last PR! I've got another (shorter) one for ya 😄 

## Changes

1. [In my last PR I mistakingly excluded a SQL `DATE` cast for the `.yesterday` and `.today` scopes](https://github.com/jonatas/timescale/pull/2/files#diff-1da9e137201481b9a6ec29702285eee685e074c6625d077b50cafc9d05652bfcR89-R90). This PR fixes that
2. The existing `.last_month` and `.last_week` scopes are confusing, they can mean different things to different people. It's better to be explicit here. As such, I renamed them to `.previous_month` and `.previous_week`. I also reworked the queries
3. I added two new scopes `.this_month` and `.this_week`, both self-exlanatory.
4. I reworked all scopes to respect the parent application's timezone
5. Finally, I updated the README to reflect the scope changes and also cleaned up documentation around usage


#### Default scopes after changes

| Scope name             | Description                                           |
|------------------------|-------------------------------------------------------|
| `Model.previous_month` | Returns all the records created in the previous month |
| `Model.previous_week`  | Returns all the records created in the previous week  |
| `Model.this_month`     | Returns all the records created this month            |
| `Model.this_week`      | Returns all the records created this week             |
| `Model.yesterday`      | Returns all the records created yesterday             |
| `Model.today`          | Returns all the records created today                 |
| `Model.last_hour`      | Returns all the records created in the last hour      |


#### Specs
Specs are taking a long time to run, I think in a follow-up I'll refactor how the tables get created, truncated, etc. to fix this. The current implementation is very inefficient (tears down tables and recreates before each block).

<img width="808" alt="Screen Shot 2021-10-05 at 1 41 48 PM" src="https://user-images.githubusercontent.com/8730447/136075051-c3cb0499-5664-4a61-9f19-62e73e9af4d4.png">

