### PR TITLE
Enhance Schema Dumper

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     timescaledb (0.1.4)
       activerecord
+      activesupport
       pg (~> 1.2)
 
 GEM
@@ -69,4 +70,4 @@ DEPENDENCIES
   timescaledb!
 
 BUNDLED WITH
-   2.1.4
+   2.2.31

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Or install it yourself as:
 
 ## Usage
 
-You can check the [all_in_one.rb](examples/all_in_one.rb) that will:
+You can check the [all_in_one.rb](examples/all_in_one.rb) example that will:
 
 1. Create hypertable with compression settings
 2. Insert data
@@ -243,7 +243,7 @@ create_table(:events, id: false, hypertable: hypertable_options) do |t|
 end
 ```
 
-#### create_continuous_aggregates
+#### create_continuous_aggregate
 
 This example shows a ticks table grouping ticks as OHLCV histograms for every
 minute.
@@ -287,8 +287,18 @@ options = {
   }
 }
 
-create_continuous_aggregates('ohlc_1m', query, **options)
+create_continuous_aggregate('ohlc_1m', query, **options)
 ```
+
+#### Scenic integration
+
+The [Scenic](https://github.com/scenic-views/scenic) gem is an easy way to
+manage database view definitions for a Rails application. TimescaleDB's
+continuous aggregates are more complex than regular PostgreSQL views, and
+the schema dumper included with Scenic can't dump a complete definition.
+
+This gem automatically configures Scenic to use a `Timescale::Scenic::Adapter`
+which will correctly handle schema dumping.
 
 ### Enable ActsAsHypertable
 

--- a/lib/timescale.rb
+++ b/lib/timescale.rb
@@ -9,6 +9,7 @@ require_relative 'timescale/dimensions'
 require_relative 'timescale/hypertable'
 require_relative 'timescale/job'
 require_relative 'timescale/job_stats'
+require_relative 'timescale/schema_dumper'
 require_relative 'timescale/stats_report'
 require_relative 'timescale/migration_helpers'
 require_relative 'timescale/version'
@@ -46,5 +47,13 @@ module Timescale
 
   def default_hypertable_options
     Timescale::ActsAsHypertable::DEFAULT_OPTIONS
+  end
+end
+
+if defined?(Scenic)
+  require_relative 'timescale/scenic/adapter'
+
+  Scenic.configure do |config|
+    config.database = Timescale::Scenic::Adapter.new
   end
 end

--- a/lib/timescale/compression_settings.rb
+++ b/lib/timescale/compression_settings.rb
@@ -1,6 +1,7 @@
 module Timescale
-  class CompressionSettings < ActiveRecord::Base
+  class CompressionSetting < ActiveRecord::Base
     self.table_name = "timescaledb_information.compression_settings"
     belongs_to :hypertable, foreign_key: :hypertable_name
   end
+  CompressionSettings = CompressionSetting
 end

--- a/lib/timescale/continuous_aggregates.rb
+++ b/lib/timescale/continuous_aggregates.rb
@@ -1,5 +1,5 @@
 module Timescale
-  class ContinuousAggregates < ActiveRecord::Base
+  class ContinuousAggregate < ActiveRecord::Base
     self.table_name = "timescaledb_information.continuous_aggregates"
     self.primary_key = 'materialization_hypertable_name'
 
@@ -15,4 +15,5 @@ module Timescale
       }
     end
   end
+  ContinuousAggregates = ContinuousAggregate
 end

--- a/lib/timescale/dimensions.rb
+++ b/lib/timescale/dimensions.rb
@@ -1,5 +1,6 @@
 module Timescale
-  class Dimensions < ActiveRecord::Base
+  class Dimension < ActiveRecord::Base
     self.table_name = "timescaledb_information.dimensions"
   end
+  Dimensions = Dimension
 end

--- a/lib/timescale/hypertable.rb
+++ b/lib/timescale/hypertable.rb
@@ -6,17 +6,17 @@ module Timescale
     has_many :jobs, foreign_key: "hypertable_name"
     has_many :chunks, foreign_key: "hypertable_name"
 
-    has_one :compression_settings,
+    has_many :compression_settings,
       foreign_key: "hypertable_name",
-      class_name: "Timescale::CompressionSettings"
+      class_name: "Timescale::CompressionSetting"
 
     has_one :dimensions,
       foreign_key: "hypertable_name",
-      class_name: "Timescale::Dimensions"
+      class_name: "Timescale::Dimension"
 
     has_many :continuous_aggregates,
       foreign_key: "hypertable_name",
-      class_name: "Timescale::ContinuousAggregates"
+      class_name: "Timescale::ContinuousAggregate"
 
     def chunks_detailed_size
       struct_from "SELECT * from chunks_detailed_size('#{self.hypertable_name}')"

--- a/lib/timescale/job.rb
+++ b/lib/timescale/job.rb
@@ -3,7 +3,8 @@ module Timescale
     self.table_name = "timescaledb_information.jobs"
     self.primary_key = "job_id"
 
-    scope :compression, -> { where(proc_name: "tsbs_compress_chunks") }
+    scope :compression, -> { where(proc_name: [:tsbs_compress_chunks, :policy_compression]) }
+    scope :refresh_continuous_aggregate, -> { where(proc_name: :policy_refresh_continuous_aggregate) }
     scope :scheduled, -> { where(scheduled: true) }
   end
 end

--- a/lib/timescale/job_stats.rb
+++ b/lib/timescale/job_stats.rb
@@ -1,5 +1,5 @@
 module Timescale
-  class JobStats < ActiveRecord::Base
+  class JobStat < ActiveRecord::Base
     self.table_name = "timescaledb_information.job_stats"
 
     belongs_to :job
@@ -13,4 +13,5 @@ module Timescale
         .to_a.map{|e|e.attributes.transform_keys(&:to_sym) }
     end
   end
+  JobStats = JobStat
 end

--- a/lib/timescale/scenic/adapter.rb
+++ b/lib/timescale/scenic/adapter.rb
@@ -1,0 +1,55 @@
+require 'scenic/adapters/postgres'
+require 'scenic/adapters/postgres/views'
+
+module Timescale
+  module Scenic
+    class Views < ::Scenic::Adapters::Postgres::Views
+      # All of the views that this connection has defined, excluding any
+      # Timescale continuous aggregates. Those should be defined using
+      # +create_continuous_aggregate+ rather than +create_view+.
+      #
+      # @return [Array<Scenic::View>]
+      def all
+        ts_views = views_from_timescale.map { |v| to_scenic_view(v) }
+        pg_views = views_from_postgres.map { |v| to_scenic_view(v) }
+        ts_view_names = ts_views.map(&:name)
+        # Skip records with matching names (includes the schema name
+        # for records not in the public schema)
+        pg_views.reject { |v| v.name.in?(ts_view_names) }
+      end
+
+      private
+
+      def views_from_timescale
+        connection.execute(<<-SQL.squish)
+          SELECT
+            view_name as viewname,
+            view_definition AS definition,
+            'm' AS kind,
+            view_schema AS namespace
+          FROM timescaledb_information.continuous_aggregates
+        SQL
+      end
+    end
+
+    class Adapter < ::Scenic::Adapters::Postgres
+      # Timescale does some funky stuff under the hood with continuous
+      # aggregates. A continuous aggregate is made up of:
+      #
+      # 1. A hypertable to store the materialized data
+      # 2. An entry in the jobs table to refresh the data
+      # 3. A view definition that union's the hypertable and any recent data
+      #    not included in the hypertable
+      #
+      # That doesn't dump well, even to structure.sql (we lose the job
+      # definition, since it's not part of the DDL).
+      #
+      # Our schema dumper implementation will handle dumping the continuous
+      # aggregate definintions, but we need to override Scenic's schema dumping
+      # to exclude those continuous aggregates.
+      def views
+        Views.new(connection).all
+      end
+    end
+  end
+end

--- a/lib/timescale/schema_dumper.rb
+++ b/lib/timescale/schema_dumper.rb
@@ -1,24 +1,87 @@
-ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper.class_eval do
-  def table(table_name, stream)
-    super(table_name, stream)
-    if hypertable=Timescale::Hypertable.find_by(hypertable_name: table_name)
+require 'active_record/connection_adapters/postgresql_adapter'
+
+module Timescale
+  module SchemaDumper
+    def tables(stream)
+      super # This will call #table for each table in the database
+      views(stream) unless defined?(Scenic) # Don't call this twice if we're using Scenic
+    end
+
+    def table(table_name, stream)
+      super(table_name, stream)
+      if hypertable = Timescale::Hypertable.find_by(hypertable_name: table_name)
+        timescale_hypertable(hypertable, stream)
+        timescale_retention_policy(hypertable, stream)
+      end
+    end
+
+    def views(stream)
+      timescale_continuous_aggregates(stream) # Define these before any Scenic views that might use them
+      super
+    end
+
+    private
+
+    def timescale_hypertable(hypertable, stream)
       dim = hypertable.dimensions
-      # TODO Build compression settings for the template:
-      # #{build_compression_settings_for(hypertable)})
-      stream.puts <<TEMPLATE
-  create_hypertable('#{table_name}',
-                    time_column: '#{dim.column_name}',
-                    chunk_time_interval: '#{dim.time_interval.inspect}')
-TEMPLATE
+      extra_settings = {
+        time_column: "#{dim.column_name}",
+        chunk_time_interval: "#{dim.time_interval.inspect}"
+      }.merge(timescale_compression_settings_for(hypertable)).map {|k, v| %Q[#{k}: "#{v}"]}.join(", ")
+
+      stream.puts %Q[  create_hypertable "#{hypertable.hypertable_name}", #{extra_settings}]
+      stream.puts
+    end
+
+    def timescale_retention_policy(hypertable, stream)
+      hypertable.jobs.where(proc_name: "policy_retention").each do |job|
+        stream.puts %Q[  create_retention_policy "#{job.hypertable_name}", interval: "#{job.config["drop_after"]}"]
+        stream.puts
+      end
+    end
+
+    def timescale_compression_settings_for(hypertable)
+      compression_settings = hypertable.compression_settings.each_with_object({}) do |setting, compression_settings|
+        compression_settings[:compress_segmentby] = setting.attname if setting.segmentby_column_index
+
+        if setting.orderby_column_index
+          direction = setting.orderby_asc ? "ASC" : "DESC"
+          compression_settings[:compress_orderby] = "#{setting.attname} #{direction}"
+        end
+      end
+
+      hypertable.jobs.compression.each do |job|
+        compression_settings[:compression_interval] = job.config["compress_after"]
+      end
+      compression_settings
+    end
+
+    def timescale_continuous_aggregates(stream)
+      Timescale::ContinuousAggregates.all.each do |aggregate|
+        opts = if (refresh_policy = aggregate.jobs.refresh_continuous_aggregate.first)
+                 interval = timescale_interval(refresh_policy.schedule_interval)
+                 end_offset = timescale_interval(refresh_policy.config["end_offset"])
+                 start_offset = timescale_interval(refresh_policy.config["start_offset"])
+                 %Q[, refresh_policies: { start_offset: "#{start_offset}", end_offset: "#{end_offset}", schedule_interval: "#{interval}"}]
+               else
+                 ""
+               end
+
+        stream.puts <<~AGG.indent(2)
+          create_continuous_aggregate("#{aggregate.view_name}", <<-SQL#{opts})
+            #{aggregate.view_definition.strip.gsub(/;$/, "")}
+          SQL
+        AGG
+        stream.puts
+      end
+    end
+
+    def timescale_interval(value)
+      return "NULL" if value.nil? || value.to_s.downcase == "null"
+
+      "INTERVAL '#{value}'"
     end
   end
 end
 
-=begin
-    def build_compression_settings_for(hypertable)
-      return if hypertable.compression_settings.nil?
-      hypertable.compression_settings.map do |settings|
-        ", compress_segmentby: #{settings.segmentby_column_index},
-                    compress_orderby: 'created_at',
-                    compression_interval: nil)
-=end
+ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper.prepend(Timescale::SchemaDumper)

--- a/timescale.gemspec
+++ b/timescale.gemspec
@@ -27,8 +27,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/tsdb}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency  "pg", "~> 1.2"
+  spec.add_dependency "pg", "~> 1.2"
   spec.add_dependency "activerecord"
+  spec.add_dependency "activesupport"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rspec-its"


### PR DESCRIPTION
* Adds retention_policy support to migration_helpers
* Adds continuous_aggregate and retention_policy support to schema_dumper
* Updates pluralization to more closely match Rails conventions
* Adds compatibility with Scenic gem